### PR TITLE
Investigate dist file origins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,18 @@
 # dependencies
 node_modules/
+
+# build output
+dist/
+*.tsbuildinfo
+
+# environment files
+.env
+.env.local
+.env.production
+
+# logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*


### PR DESCRIPTION
Update `.gitignore` to exclude build output and environment files.

This prevents merge conflicts caused by automatically generated files like `dist/` and keeps the repository focused on source code.

---
<a href="https://cursor.com/background-agent?bcId=bc-4c3dafd8-e0f5-4de1-be1c-729584a20c09">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4c3dafd8-e0f5-4de1-be1c-729584a20c09">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

