### PR TITLE
refactor(api): standardize and refactor endpoints to RESTful conventions

### DIFF
--- a/src/controllers/backOfficeUser.controller.ts
+++ b/src/controllers/backOfficeUser.controller.ts
@@ -168,47 +168,37 @@ class BackOfficeUserController {
     }
   }
 
-  static async getAllUsers(_req: Request, res: Response) {
+  static async getUsers(req: Request, res: Response) {
     try {
+      const limitVal = req.query.limit ?? req.params.limit;
+      if (limitVal !== undefined) {
+        const limitNum = Number(limitVal);
+        if (isNaN(limitNum) || limitNum <= 0) {
+          logger.warn("Requested number of users is zero or invalid.");
+          return res.status(400).json({
+            success: false,
+            message: "Limit must be greater than zero.",
+          });
+        }
+        const data = await backofficeUserService.getNumberOfBackOfficeUsers(limitNum);
+        logger.info("Fetched number of backoffice users.", { count: limitNum });
+        return res.status(200).json({
+          success: true,
+          message: `Retrieved ${limitNum} back office users successfully.`,
+          data,
+        });
+      }
+
       const data = await backofficeUserService.getAll();
       logger.info("Fetched all backoffice users.");
-      res.status(200).json({
+      return res.status(200).json({
         success: true,
         message: "Users retrieved successfully.",
         data,
       });
     } catch (err: any) {
-      logger.error("Get All Users Error", { error: err.message });
-      res.status(500).json({
-        success: false,
-        message: "Failed to retrieve users.",
-        error: err.message,
-      });
-    }
-  }
-
-  static async getNumberOfBackOfficeUsers(req: Request, res: Response) {
-    try {
-      const { number } = req.params;
-      const data = await backofficeUserService.getNumberOfBackOfficeUsers(Number(number));
-
-      if (Number(number) === 0) {
-        logger.warn("Requested number of users is zero.");
-        return res.status(400).json({
-          success: false,
-          message: "Number must be greater than zero.",
-        });
-      }
-
-      logger.info("Fetched number of backoffice users.", { count: number });
-      res.status(200).json({
-        success: true,
-        message: `Retrieved ${number} back office users successfully.`,
-        data,
-      });
-    } catch (err: any) {
-      logger.error("Get Number of BackOffice Users Error", { error: err.message });
-      res.status(500).json({
+      logger.error("Get Users Error", { error: err.message });
+      return res.status(500).json({
         success: false,
         message: "Failed to retrieve users.",
         error: err.message,

--- a/src/controllers/user.controller.ts
+++ b/src/controllers/user.controller.ts
@@ -249,18 +249,18 @@ export class UserController {
   }
 
   // Get user profile by Id
-  static async fetch_user_profile(req : Request, res : Response) : Promise<void>{
+  static async fetch_user_profile(req: Request, res: Response): Promise<void> {
     try {
       const id = req.params.id ?? req.query.id;
 
-      if (!id || typeof id !== "string"){
+      if (!id || typeof id !== "string") {
         res.status(400).json({ success: false, message: "Id is required and must be a string." });
         return;
       }
 
       const user = await GetUserDataService.getById(id);
-      res.status(200).json({success : true,data : user});
-    } catch (error : any) {
+      res.status(200).json({ success: true, data: user });
+    } catch (error: any) {
       logger.error("GetById Error:", error.message);
       if (error instanceof CustomException) res.status(404).json({ success: false, message: error.message });
       else res.status(500).json({ success: false, message: "Internal server error." });
@@ -271,7 +271,7 @@ export class UserController {
   // Get push notification status
   // -------------------------
   static async getAllowPushNotificationStatus(req: Request, res: Response): Promise<void> {
-    const id = req.body.Id ?? req.body.id;
+    const id = req.body.Id ?? req.body.id ?? req.params.id ?? req.params.Id;
     if (!id || typeof id !== "string") {
       res.status(400).json({ success: false, message: "A valid user ID is required." });
       return;
@@ -290,7 +290,7 @@ export class UserController {
   // Get FCM token by username
   // -------------------------
   static async getFCMTokenByUsername(req: Request, res: Response): Promise<void> {
-    const username = req.body.Username ?? req.body.username;
+    const username = req.body.Username ?? req.body.username ?? req.query.username ?? req.query.Username;
     if (!username || typeof username !== "string") {
       res.status(400).json({ success: false, message: "Username is required and must be a string." });
       return;

--- a/src/routes/auth.routes.ts
+++ b/src/routes/auth.routes.ts
@@ -5,12 +5,12 @@ import { authenticateJWT } from '../middlewares/auth.middleware.js';
 
 const router = Router();
 router.post('/signup', AuthController.signup);
-router.put('/change-password',authenticateJWT,AuthController.changePassword);
+router.put('/change-password', authenticateJWT, AuthController.changePassword);
 router.post("/request-reset", AuthController.sendPasswordToken);
 router.post("/reset-password", AuthController.resetPassword);
 router.post('/login', AuthController.authenticate);
-router.post('/logout', authenticateJWT,AuthController.logout);
-router.get("/usernameAlreadyExists", AuthController.usernameAlreadyExists);
-router.get("/isValidEmail", AuthController.isValidEmail);
+router.post('/logout', authenticateJWT, AuthController.logout);
+router.get("/usernames/exists", AuthController.usernameAlreadyExists);
+router.get("/validate-email", AuthController.isValidEmail)
 
 export default router;

--- a/src/routes/backOfficeUser.routes.ts
+++ b/src/routes/backOfficeUser.routes.ts
@@ -11,10 +11,9 @@ router.post("/reset-password", BackOfficeUserController.resetPassword);
 
 router.post("/logout", authenticateJWT, authorizeRole('BACKOFFICE_USER'), BackOfficeUserController.logoutController);
 router.post("/change-password", authenticateJWT, authorizeRole('BACKOFFICE_USER'), BackOfficeUserController.changePassword);
-router.get("/", authenticateJWT, authorizeRole('BACKOFFICE_USER'), BackOfficeUserController.getAllUsers);
-router.get("/count/:number", authenticateJWT, authorizeRole('BACKOFFICE_USER'), BackOfficeUserController.getNumberOfBackOfficeUsers);
+router.get("/", authenticateJWT, authorizeRole('BACKOFFICE_USER'), BackOfficeUserController.getUsers);
 router.delete("/:id", authenticateJWT, authorizeRole('BACKOFFICE_USER'), BackOfficeUserController.deleteUser);
 router.put("/:id", authenticateJWT, authorizeRole('BACKOFFICE_USER'), BackOfficeUserController.updateUser);
-router.get("/test/:id", authenticateJWT, authorizeRole('BACKOFFICE_USER'), BackOfficeUserController.testUserById);
+router.get("/:id", authenticateJWT, authorizeRole('BACKOFFICE_USER'), BackOfficeUserController.testUserById);
 
 export default router;

--- a/src/routes/fcm.routes.ts
+++ b/src/routes/fcm.routes.ts
@@ -4,6 +4,6 @@ import { FCMController } from '../controllers/fcmToken.controller';
 import { authenticateJWT } from "../middlewares/auth.middleware";
 
 const router = Router();
-router.put('/update-fcm-token', authenticateJWT,FCMController.updateFCMToken);
+router.put('/token', authenticateJWT, FCMController.updateFCMToken);
 
 export default router;

--- a/src/routes/neckAngle.routes.ts
+++ b/src/routes/neckAngle.routes.ts
@@ -6,16 +6,14 @@ import { authenticateJWT } from '../middlewares/auth.middleware.js';
 const router = express.Router();
 
 
-router.post('/neckangle/postBatchNeckAngleRecords', NeckAngleController.postBatchNeckAngleRecords);
-router.post('/neckangle/postrandomneckanglerecords', NeckAngleController.postRandomTestBatchNeckAngleRecords);
-router.get('/neck-angle-stats', authenticateJWT, NeckAngleController.getUserNeckAngleStatistics);
 //// router.post('/neckangle/sendPushNotificationMessageForAverageNeckAngle', NeckAngleController.sendPushNotificationMessageForAverageNeckAngle);   
 // //the sendPushNotificationMessageForAverageNeckAngle was commented out in neck angle controller
-router.post('/neckangle/resetNotificationCount/:userId', NeckAngleController.resetNotificationCount);
-router.get('/neckangle/getUsersForTesting', NeckAngleController.getUsersForTesting);
-router.get('/neckangle/getCurrentDayAverageNeckAngleTextReport', NeckAngleController.getCurrentDayAverageNeckAngleTextReport);
-router.post('/postBatchNeckAngleRecords', NeckAngleController.postBatchNeckAngleRecords);
-router.post('/postrandomneckanglerecords', NeckAngleController.postRandomTestBatchNeckAngleRecords);
-router.post("/weekly-averages", NeckAngleController.getWeeklyNeckAngleAverages);
+router.post('/records/batch', NeckAngleController.postBatchNeckAngleRecords);
+router.post('/records/random', NeckAngleController.postRandomTestBatchNeckAngleRecords);
+router.get('/stats', authenticateJWT, NeckAngleController.getUserNeckAngleStatistics);
+router.post('/users/:userId/notification-count/reset', NeckAngleController.resetNotificationCount);
+router.get('/test-users', NeckAngleController.getUsersForTesting);
+router.get('/reports/current-day', NeckAngleController.getCurrentDayAverageNeckAngleTextReport);
+router.post('/weekly-averages', NeckAngleController.getWeeklyNeckAngleAverages);
 
 export default router;

--- a/src/routes/transaction.routes.ts
+++ b/src/routes/transaction.routes.ts
@@ -9,7 +9,7 @@ router.get("/", TransactionController.getAllTransactionRecords);
 
 router.get("/:id", TransactionController.getTransactionRecordById);
 
-router.get("/user/:userId", TransactionController.getTransactionRecordsByUserId);
+router.get("/users/:userId", TransactionController.getTransactionRecordsByUserId);
 
 router.post("/", TransactionController.createTransactionRecord);
 

--- a/src/routes/user.routes.ts
+++ b/src/routes/user.routes.ts
@@ -5,25 +5,33 @@ import { authenticateJWT } from "../middlewares/auth.middleware.js";
 
 const router = Router();
 
-router.put("/update", authenticateJWT, UserController.updateUser);
+// Static GET routes
+router.get("/response-rate", UserController.getResponseRate);
+router.get("/usernames/exists", AuthController.usernameAlreadyExists);
+router.get("/emails/validate", AuthController.isValidEmail);
+router.get("/deletions/confirm", UserController.confirmDeleteMyAccount);
+router.get("/fcm-token", UserController.getFCMTokenByUsername);
+router.get("/", UserController.getByEmail);
 
-router.put("/updatepictureurl", authenticateJWT, UserController.updatePictureUrl);
-router.put("/updatesubscription/:id", UserController.updateSubscription);
+// Parametric GET routes
+router.get("/:id/push-notifications", UserController.getAllowPushNotificationStatus);
+router.get("/:id", UserController.fetch_user_profile);
 
-// router.post("/postresponserate", UserController.postResponseRate);
-router.get("/getresponserate", UserController.getResponseRate);
+// Static PUT routes
+router.put("/", authenticateJWT, UserController.updateUser);
+router.put("/picture", authenticateJWT, UserController.updatePictureUrl);
+
+// Parametric PUT routes
+router.put("/:id/subscription", UserController.updateSubscription);
+router.put("/:id/push-notifications", UserController.toggleAllowPushNotifications);
+router.put("/:id/fcm-token", UserController.updateFCMToken);
+
+// Static POST routes
 router.post('/logout', authenticateJWT, AuthController.logout);
-router.get("/usernameAlreadyExists", AuthController.usernameAlreadyExists);
-router.get('/fetch_user_profile/:id',UserController.fetch_user_profile);
-router.get("/isValidEmail", AuthController.isValidEmail);
-router.post("/toggleallowpushnotifications/:id", UserController.toggleAllowPushNotifications);
-router.delete("/deleteaccount/:id", UserController.deleteById);
-router.delete("/deletemyaccount", UserController.deleteMyAccount);
-router.get("/confirmdeletemyaccount", UserController.confirmDeleteMyAccount);
-router.delete("/deleteall", UserController.deleteAll);
-router.get("/getByEmail", UserController.getByEmail);
-router.get("/getAllowPushNotificationStatus", UserController.getAllowPushNotificationStatus);
-router.get("/getFCMToken", UserController.getFCMTokenByUsername);
-router.put("/updateFCMToken", UserController.updateFCMToken);
+router.post("/deletion-requests", UserController.deleteMyAccount);
+
+// DELETE routes
+router.delete("/", UserController.deleteAll);
+router.delete("/:id", UserController.deleteById);
 
 export default router;


### PR DESCRIPTION
Refactor routing files and their associated controller logic to align with RESTful endpoint naming standards and resolve routing conflicts:

- Standardize user routes under `/users` including static and parametric ordering to prevent routing mismatches.
- Convert verb-based endpoints (e.g., `/updatepictureurl`, `/updatesubscription/:id`) to resource-oriented paths (e.g., `/picture`, `/:id/subscription`).
- Consolidate back office user retrieval endpoints, replacing `getNumberOfBackOfficeUsers` and `getAllUsers` with a single `getUsers` controller that handles optional limit query/route parameters.
- Standardize endpoints for FCM tokens, neck angle records, transaction records, and authentication.
- Improve request parameter/payload verification within controller functions.